### PR TITLE
RHTAPSRE-458: Allow all urls by default

### DIFF
--- a/api/v1alpha1/repository_webhook.go
+++ b/api/v1alpha1/repository_webhook.go
@@ -50,7 +50,7 @@ func (u *URLValidationFailedError) Error() string {
 
 func (u *URLValidator) Validate(url string) (admission.Warnings, error) {
 	for _, urlPrefix := range u.URLPrefixAllowList {
-		if strings.HasPrefix(url, urlPrefix) {
+		if urlPrefix == "" || strings.HasPrefix(url, urlPrefix) {
 			return nil, nil
 		}
 	}
@@ -111,8 +111,8 @@ type FileReader func(name string) ([]byte, error)
 // Load the URL prefix' of allowed URLs from a file
 func LoadUrlPrefixAllowListFromFile(path string, fileReader FileReader) ([]string, error) {
 	if path == "" {
-		log.Info("URL prefix allow list config was not provided")
-		return []string{}, nil
+		log.Info("URL prefix allow list config was not provided, allow all urls")
+		return []string{""}, nil
 	}
 
 	content, err := fileReader(path)

--- a/api/v1alpha1/repository_webhook_unit_test.go
+++ b/api/v1alpha1/repository_webhook_unit_test.go
@@ -56,7 +56,7 @@ func TestLoadUrlPrefixAllowListFromFile(t *testing.T) {
 			fileReader: func(name string) ([]byte, error) {
 				return nil, nil
 			},
-			want:    []string{},
+			want:    []string{""},
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
If not config was provided to the webhook deployment, allow the creation of repositories with any url. This will make it safer to deploy the webhook.